### PR TITLE
feat: add fluid typography scale

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -49,6 +49,12 @@
   --shadow-2xl: 0px 2px 0px 0px hsl(142, 76%, 36% / 0.00);
   --tracking-normal: 0em;
   --spacing: 0.25rem;
+  --font-step--2: clamp(0.75rem, 0.4vw + 0.6rem, 0.875rem);
+  --font-step--1: clamp(0.875rem, 0.6vw + 0.7rem, 1rem);
+  --font-step-0: clamp(1rem, 1.2vw + 0.9rem, 1.125rem);
+  --font-step-1: clamp(1.25rem, 1.6vw + 1rem, 1.5rem);
+  --font-step-2: clamp(1.5rem, 2vw + 1.25rem, 1.875rem);
+  --font-step-3: clamp(1.875rem, 2.4vw + 1.5rem, 2.35rem);
 }
 
 .dark {
@@ -85,7 +91,66 @@
 
   body {
     @apply font-sans antialiased bg-background text-foreground;
-    font-size: 1.325rem;
+    font-size: var(--font-step-0);
+    line-height: 1.6;
+    letter-spacing: 0.005em;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    @apply font-sans;
+    font-weight: 600;
+    color: inherit;
+  }
+
+  h1 {
+    font-size: var(--font-step-3);
+    line-height: 1.1;
+    letter-spacing: -0.025em;
+    font-weight: 700;
+  }
+
+  h2 {
+    font-size: var(--font-step-2);
+    line-height: 1.15;
+    letter-spacing: -0.02em;
+  }
+
+  h3 {
+    font-size: var(--font-step-1);
+    line-height: 1.25;
+    letter-spacing: -0.015em;
+  }
+
+  h4 {
+    font-size: var(--font-step-0);
+    line-height: 1.3;
+    letter-spacing: -0.01em;
+  }
+
+  h5 {
+    font-size: var(--font-step--1);
+    line-height: 1.35;
+    letter-spacing: -0.005em;
+  }
+
+  h6 {
+    font-size: var(--font-step--2);
+    line-height: 1.4;
+    letter-spacing: 0;
+  }
+
+  small,
+  .caption {
+    font-size: var(--font-step--1);
+    line-height: 1.45;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    display: inline-block;
   }
 }
 


### PR DESCRIPTION
## Summary
- replace the static body type size with a fluid clamp-based scale and balanced line-height
- introduce modular clamp steps for headings, subheads, and captions with consistent letter-spacing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d42b817700832e8156d82c962ecc8d