### PR TITLE
Adjust header nav styling and add glass effect

### DIFF
--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -19,7 +19,10 @@ export default function Header() {
   ];
 
   return (
-    <header className="bg-card border-b border-border sticky top-0 z-50" data-testid="header">
+    <header
+      className="bg-card/90 backdrop-blur-md border-b border-border shadow-sm sticky top-0 z-50"
+      data-testid="header"
+    >
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center h-16">
           <div className="flex items-center">
@@ -38,7 +41,7 @@ export default function Header() {
                 <Link
                   key={item.name}
                   href={item.href}
-                  className="text-foreground hover:text-primary px-3 py-2 text-xl font-bold transition-colors"
+                  className="text-foreground hover:text-primary px-3 py-2 text-[0.95rem] font-semibold transition-colors"
                   data-testid={`nav-${item.name.toLowerCase()}`}
                 >
                   {item.name}
@@ -71,7 +74,7 @@ export default function Header() {
                     <Link
                       key={item.name}
                       href={item.href}
-                      className="text-foreground hover:text-primary px-3 py-2 text-xl font-bold transition-colors"
+                      className="text-foreground hover:text-primary px-3 py-2 text-base font-semibold transition-colors"
                       onClick={() => setIsOpen(false)}
                       data-testid={`mobile-nav-${item.name.toLowerCase()}`}
                     >


### PR DESCRIPTION
## Summary
- soften the sticky header background with a translucent layer, blur, and subtle shadow to create a floating effect
- reduce desktop nav link typography to semibold 0.95rem for better balance with the logo
- align mobile nav link styling with the lighter typography treatment

## Testing
- `npm run check` *(fails: existing TypeScript errors in AdminDashboard, community-detail, and storage files)*

------
https://chatgpt.com/codex/tasks/task_e_68d42b957f6c832e93e8bf5966c94657