### PR TITLE
Replace hero gradient overlay with neutral tint

### DIFF
--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -107,13 +107,13 @@ export default function Home() {
     <div className="min-h-screen bg-white">
       {/* Hero Section */}
       <section className="relative overflow-hidden">
-        <div className="absolute inset-0 bg-gradient-to-br from-primary/90 via-primary/80 to-primary/70" />
         <img
           src="https://images.unsplash.com/photo-1576013551627-0cc20b96c2a7?q=80&w=1600&auto=format&fit=crop"
           alt="Senior living community with beautiful gardens"
-          className="absolute inset-0 h-full w-full object-cover mix-blend-overlay"
+          className="absolute inset-0 h-full w-full object-cover"
         />
-        <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-20 sm:py-28 text-white">
+        <div className="absolute inset-0 bg-slate-900/70" aria-hidden="true" />
+        <div className="relative z-10 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-20 sm:py-28 text-white">
           <div className="max-w-3xl">
             <p className="uppercase tracking-widest text-white/80 text-xs mb-2" data-testid="hero-tagline">
               Locally Owned • Resident‑Focused


### PR DESCRIPTION
## Summary
- replace the home hero's primary gradient overlay with a translucent slate tint to avoid muddy midtones while keeping the image visible
- raise the hero content above the overlay layer for consistent readability

## Testing
- npm run check *(fails: existing type errors in AdminDashboard, community detail page, and server storage definitions)*

------
https://chatgpt.com/codex/tasks/task_e_68d42bbc06f4832eae0b1d3eb05df960