### PR TITLE
Ensure community detail pages scroll to top on load

### DIFF
--- a/client/src/pages/community-detail.tsx
+++ b/client/src/pages/community-detail.tsx
@@ -1,6 +1,6 @@
 import { useParams } from "wouter";
 import { useQuery } from "@tanstack/react-query";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -48,6 +48,13 @@ export default function CommunityDetail() {
   const [selectedFloorPlan, setSelectedFloorPlan] = useState<FloorPlan | null>(null);
   const [isFloorPlanModalOpen, setIsFloorPlanModalOpen] = useState(false);
   const [selectedGalleryCategory, setSelectedGalleryCategory] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (!slug || window.location.hash) return;
+
+    window.scrollTo({ top: 0, left: 0, behavior: "auto" });
+  }, [slug]);
 
   const { data: community, isLoading: communityLoading } = useQuery<Community>({
     queryKey: [`/api/communities/${slug}`],


### PR DESCRIPTION
## Summary
- scroll the window to the top when navigating to a community detail page unless a hash anchor is present
- guard against running the scroll effect during SSR or when the slug is missing

## Testing
- npm run check *(fails: existing TypeScript errors in AdminDashboard and storage modules)*

------
https://chatgpt.com/codex/tasks/task_e_68d42ed205e4832eb83998c9b710b062