### PR TITLE
Remove mini map card from community detail sidebar

### DIFF
--- a/client/src/pages/community-detail.tsx
+++ b/client/src/pages/community-detail.tsx
@@ -846,25 +846,6 @@ export default function CommunityDetail() {
                 </CardContent>
               </Card>
 
-              {/* Mini Map */}
-              <Card className="shadow-lg">
-                <CardContent className="p-0">
-                  <div className="h-48 bg-gray-100 rounded-lg flex items-center justify-center" data-testid="mini-map">
-                    <div className="text-center text-gray-500">
-                      <MapPin className="w-8 h-8 mx-auto mb-2" />
-                      <p className="text-sm font-medium">{community.city}, {community.state}</p>
-                      <Button 
-                        variant="link" 
-                        size="sm" 
-                        className="mt-2"
-                        data-testid="button-get-directions"
-                      >
-                        Get Directions →
-                      </Button>
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- remove the redundant mini map card from the community detail sidebar layout

## Testing
- npm run check *(fails: existing TypeScript errors in AdminDashboard and storage modules)*

------
https://chatgpt.com/codex/tasks/task_e_68d4302e77d0832ea131b1d427f0bffb