### PR TITLE
Add Leaflet map to community detail page

### DIFF
--- a/client/src/components/CommunityLocationMap.tsx
+++ b/client/src/components/CommunityLocationMap.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useRef } from "react";
+import L from "leaflet";
+import "leaflet/dist/leaflet.css";
+import type { Community } from "@shared/schema";
+import { cn } from "@/lib/utils";
+
+// Ensure default marker assets load correctly in Vite
+delete (L.Icon.Default.prototype as any)._getIconUrl;
+L.Icon.Default.mergeOptions({
+  iconRetinaUrl: "https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.7.1/images/marker-icon-2x.png",
+  iconUrl: "https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.7.1/images/marker-icon.png",
+  shadowUrl: "https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.7.1/images/marker-shadow.png",
+});
+
+export function getCommunityCoordinates(community: Community) {
+  const parseCoordinate = (value: unknown): number | null => {
+    if (value === null || value === undefined) return null;
+    if (typeof value === "number") return Number.isFinite(value) ? value : null;
+    const parsed = parseFloat(String(value));
+    return Number.isFinite(parsed) ? parsed : null;
+  };
+
+  const lat =
+    parseCoordinate(community.latitude) ??
+    parseCoordinate((community as Record<string, unknown>).lat);
+  const lng =
+    parseCoordinate(community.longitude) ??
+    parseCoordinate((community as Record<string, unknown>).lng);
+
+  if (lat === null || lng === null) {
+    return null;
+  }
+
+  return { lat, lng };
+}
+
+interface CommunityLocationMapProps {
+  community: Community;
+  coordinates: { lat: number; lng: number };
+  className?: string;
+  zoom?: number;
+}
+
+export default function CommunityLocationMap({
+  community,
+  coordinates,
+  className,
+  zoom = 14,
+}: CommunityLocationMapProps) {
+  const mapRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!mapRef.current) return;
+
+    const map = L.map(mapRef.current, {
+      center: [coordinates.lat, coordinates.lng],
+      zoom,
+      scrollWheelZoom: false,
+      doubleClickZoom: false,
+    });
+
+    L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+      attribution: "© OpenStreetMap contributors",
+    }).addTo(map);
+
+    const marker = L.marker([coordinates.lat, coordinates.lng]).addTo(map);
+    marker.bindPopup(
+      `<strong>${community.name}</strong><br/>${
+        community.address || `${community.city}, ${community.state}`
+      }`
+    );
+
+    // Defer size invalidation to ensure Leaflet renders correctly inside React layouts
+    setTimeout(() => {
+      map.invalidateSize();
+    }, 0);
+
+    return () => {
+      map.remove();
+    };
+  }, [community.address, community.city, community.name, community.state, coordinates.lat, coordinates.lng, zoom]);
+
+  return (
+    <div
+      ref={mapRef}
+      className={cn("w-full h-full rounded-lg", className)}
+      role="img"
+      aria-label={`Map showing ${community.name} location`}
+    />
+  );
+}

--- a/client/src/pages/community-detail.tsx
+++ b/client/src/pages/community-detail.tsx
@@ -10,6 +10,7 @@ import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
 import EventCard from "@/components/EventCard";
 import FloorPlanModal from "@/components/FloorPlanModal";
+import CommunityLocationMap, { getCommunityCoordinates } from "@/components/CommunityLocationMap";
 import { 
   MapPin, 
   Phone, 
@@ -139,6 +140,17 @@ export default function CommunityDetail() {
     if (!price) return "Contact for pricing";
     return `$${price.toLocaleString()}`;
   };
+
+  const coordinates = getCommunityCoordinates(community);
+  const streetAddress = community.address?.trim() || community.street?.trim() || "";
+  const cityState = [community.city, community.state].filter(Boolean).join(", ");
+  const postalCode = (community.zipCode || community.zip || "").toString().trim();
+  const locationLine = [cityState, postalCode].filter(part => part && part.trim().length > 0).join(" ").trim();
+  const fullAddress = [streetAddress, locationLine].filter(part => part && part.trim().length > 0).join(", ");
+  const directionsQuery = coordinates
+    ? `${coordinates.lat},${coordinates.lng}`
+    : fullAddress || `${community.city}, ${community.state}`;
+  const directionsUrl = `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(directionsQuery)}`;
 
   const getAmenityIcon = (amenity: string) => {
     const amenityLower = amenity.toLowerCase();
@@ -849,20 +861,56 @@ export default function CommunityDetail() {
               {/* Mini Map */}
               <Card className="shadow-lg">
                 <CardContent className="p-0">
-                  <div className="h-48 bg-gray-100 rounded-lg flex items-center justify-center" data-testid="mini-map">
-                    <div className="text-center text-gray-500">
+                  {coordinates ? (
+                    <div className="relative h-48" data-testid="mini-map">
+                      <CommunityLocationMap
+                        community={community}
+                        coordinates={coordinates}
+                        className="h-full w-full"
+                      />
+                      <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/80 via-black/50 to-transparent text-white p-4">
+                        <div className="flex items-center gap-2 text-sm font-medium">
+                          <MapPin className="w-4 h-4" />
+                          <span>{fullAddress || `${community.city}, ${community.state}`}</span>
+                        </div>
+                        <Button
+                          variant="link"
+                          size="sm"
+                          className="mt-2 px-0 text-white hover:text-white/90"
+                          data-testid="button-get-directions"
+                          asChild
+                        >
+                          <a href={directionsUrl} target="_blank" rel="noreferrer">
+                            Get Directions →
+                          </a>
+                        </Button>
+                      </div>
+                    </div>
+                  ) : (
+                    <div
+                      className="h-48 bg-gray-100 rounded-lg flex flex-col items-center justify-center text-gray-500 px-4 text-center"
+                      data-testid="mini-map"
+                    >
                       <MapPin className="w-8 h-8 mx-auto mb-2" />
-                      <p className="text-sm font-medium">{community.city}, {community.state}</p>
-                      <Button 
-                        variant="link" 
-                        size="sm" 
+                      <p className="text-sm font-medium">
+                        {community.city}, {community.state}
+                      </p>
+                      <p className="text-xs text-muted-foreground mt-1">
+                        Location details coming soon.
+                      </p>
+                      <Button
+                        variant="link"
+                        size="sm"
                         className="mt-2"
                         data-testid="button-get-directions"
+                        asChild
                       >
-                        Get Directions →
+                        <a href={directionsUrl} target="_blank" rel="noreferrer">
+                          Get Directions →
+                        </a>
                       </Button>
                     </div>
-                  </div>
+                  )}
                 </CardContent>
               </Card>
             </div>


### PR DESCRIPTION
## Summary
- add a reusable CommunityLocationMap component that renders a Leaflet map for a community
- replace the community detail mini map placeholder with the interactive map and improved directions link

## Testing
- npm run check *(fails: existing TypeScript errors in AdminDashboard.tsx and server/storage.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d4653e5b38832ea71279c9ec47e62f